### PR TITLE
Fix Security Vulnerability

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -12,5 +12,9 @@
         "destination": "/index.html"
       }
     ]
+  },
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
   }
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,10 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow get: if true;
+      allow list: if false;
+      allow create: if true;
+    }
+  }
+}

--- a/src/EmailBox.tsx
+++ b/src/EmailBox.tsx
@@ -1,21 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Confetti from 'react-dom-confetti';
 import Result from './Result';
 import styles from './EmailBox.module.css';
 import { ResultType } from './types';
-import { getEmails, addEmail } from './firebase/api';
+import addEmail from './firebase/api';
 
 export default (): React.ReactElement => {
   const [email, setEmail] = useState<string>('');
-  const [emails, setEmails] = useState<string[]>([]);
   const [result, setResult] = useState<ResultType>('None');
-
-  const fetchData = async (): Promise<void | string[]> => getEmails().then((res) => res);
-
-  useEffect(() => {
-    fetchData()
-      .then((list) => list && setEmails(list));
-  }, []);
 
   const validEmail = (input: string): boolean => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(input);
 
@@ -36,22 +28,20 @@ export default (): React.ReactElement => {
   };
 
   const submitEmail = async (): Promise<void> => {
-    try {
-      setResult('Loading');
-      if (!validEmail(email)) {
-        setResult('invalidInput');
-        return;
-      }
-      if (emails.includes(email)) {
-        setResult('exists');
-        return;
-      }
-      addEmail(email);
-      setEmail('');
-      setResult('Success');
-    } catch (err) {
-      setResult('Error');
+    setResult('Loading');
+    if (!validEmail(email)) {
+      setResult('invalidInput');
+      return;
     }
+    addEmail(email)
+      .then(() => {
+        setEmail('');
+        setResult('Success');
+      })
+      .catch(() => {
+        // Duplicate email
+        setResult('exists');
+      });
   };
 
   return (

--- a/src/firebase/api.ts
+++ b/src/firebase/api.ts
@@ -14,15 +14,8 @@ const firebaseConfig = {
 
 firebase.initializeApp(firebaseConfig);
 
-const emailsCollection = firebase.firestore().collection('emails');
+const emailsIDCollection = firebase.firestore().collection('emails_id');
 
-export const addEmail = (email: string): void => {
-  emailsCollection.add({
-    email,
-  });
-};
+const addEmail = (email: string): Promise<void> => emailsIDCollection.doc(email).set({ email });
 
-export const getEmails = async (): Promise<string[]> => {
-  const snapshot = await emailsCollection.get();
-  return snapshot.docs.map((doc) => doc.data().email);
-};
+export default addEmail;


### PR DESCRIPTION
Previously database permissions were open allowing anyone to read or write to Firestore. The issue is anyone could clone my repo and place a `console.log` and read all the emails. 😞I need this read permission to determine if an email input is a duplicate (already in database) so I can't just universally disallow all reads.

In this pull request, I apply a work around by storing the email as the document id and restricting write access to just `allow create: if true`. Now anyone can add new emails to the database, but if they happen to add an email that is already in the database Firebase will interpret this operation as an update and no one has update permissions. This allows for duplicate checking while still not requiring blanket reads, allowing me to disable list read permissions for all. 🎉 

I have also applied a migration step to convert all previous documents in `emails` collection to documents with `id: email` and content `email: email` (content is irrelevant though). These new emails are now in a new collection `email_ids`. Firebase, with good reason, does not allow changing the id of existing documents.

